### PR TITLE
bacon: Fix CTS failure

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -373,7 +373,7 @@ static char *camera_get_parameters(struct camera_device *device)
     if (CAMERA_ID(device) == BACK_CAMERA_ID) {
         /* Disable 352x288 preview sizes, the combination of this preview size and larger resolutions stalls the HAL */
         params.set(CameraParameters::KEY_SUPPORTED_PREVIEW_SIZES,
-            "1920x1080,1440x1080,1280x960,1280x720,768x432,720x480,640x480,576x432,384x288,320x240");
+            "1920x1080,1440x1080,1280x720,768x432,720x480,640x480,576x432,384x288,320x240");
         params.set(CameraParameters::KEY_SUPPORTED_VIDEO_SIZES,
             "4096x2160,3840x2160,1920x1080,1440x1080,1280x720,864x480,800x480,720x480,640x480,480x320,384x288,352x288,320x240,176x144");
         params.set(CameraParameters::KEY_SUPPORTED_PICTURE_SIZES,
@@ -385,6 +385,8 @@ static char *camera_get_parameters(struct camera_device *device)
         /* Inject all supported resolutions */
         params.set(CameraParameters::KEY_SUPPORTED_VIDEO_SIZES,
             "1280x720,864x480,800x480,720x480,640x480,480x320,384x288,352x288,320x240,176x144");
+        params.set(CameraParameters::KEY_SUPPORTED_PREVIEW_SIZES,
+            "1280x720,768x432,720x480,640x480,576x432,384x288,320x240");
     }
 
     return strdup(params.flatten().string());


### PR DESCRIPTION
- Camera HAL is reporting an invalid preview resolution on the front
  camera, which fails if used for timelapse.
- Fixes android.media.cts.MediaRecorderTest#testRecorderTimelapsedVideo

Change-Id: Ib23fd57b9acb124194056a510bc85ad55760cd21
