### PR TITLE
bacon: camera: Fix reported field of view

### DIFF
--- a/camera/CameraWrapper.cpp
+++ b/camera/CameraWrapper.cpp
@@ -381,6 +381,7 @@ static char *camera_get_parameters(struct camera_device *device)
         params.set("preview-fps-range-values", "(7500,30000),(8000,30000),(30000,30000)");
         params.set("supported-live-snapshot-sizes",
             "3200x2400,2592x1944,2048x1536,1920x1080,1600x1200,1280x768,1280x720,1024x768,800x600,864x480,800x480,720x480,640x480,320x240");
+        params.set(CameraParameters::KEY_HORIZONTAL_VIEW_ANGLE, "60.0");
     } else if (CAMERA_ID(device) == FRONT_CAMERA_ID) { 
         /* Inject all supported resolutions */
         params.set(CameraParameters::KEY_SUPPORTED_VIDEO_SIZES,
@@ -388,6 +389,12 @@ static char *camera_get_parameters(struct camera_device *device)
         params.set(CameraParameters::KEY_SUPPORTED_PREVIEW_SIZES,
             "1280x720,720x480,640x480,576x432,320x240");
         params.set("preview-fps-range-values", "(7500,30000),(8000,30000),(30000,30000)");
+        if(strcmp(params.get(CameraParameters::KEY_PICTURE_SIZE), "352x288") == 0 ||
+           strcmp(params.get(CameraParameters::KEY_PICTURE_SIZE), "176x144") == 0) {
+            params.set(CameraParameters::KEY_HORIZONTAL_VIEW_ANGLE, "61.0");
+        } else {
+            params.set(CameraParameters::KEY_HORIZONTAL_VIEW_ANGLE, "65.5");
+        }
     }
 
     return strdup(params.flatten().string());


### PR DESCRIPTION
Use HAL wrapper to intercept and correct the FOV reported by
the camera primarily to fix CTS Verifier.

Change-Id: I53d05210f2663b9c780ba08c9d470748ac216e81
