### PR TITLE
bacon: Disable 16-bit PCM offload for good

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -33,7 +33,7 @@ audio.offload.buffer.size.kb=32
 audio.offload.video=true
 audio.offload.multiple.enabled=false
 audio.offload.gapless.enabled=true
-audio.offload.pcm.16bit.enable=true
+audio.offload.pcm.16bit.enable=false
 audio.offload.pcm.24bit.enable=true
 av.streaming.offload.enable=true
 


### PR DESCRIPTION
- While this can save a small amount of power during FLAC (and other
  software codecs) playback, the DSP appears to have concurrency issues
  in this mode where the stream can get muted.
- Repro case is to play 16-bit FLAC while using Google Nav. The voice
  in Nav will occasionally be muted.
- This mode also seems to provoke RTAC errors when Waves is enabled.
- The issue is not seen for 24-bit PCM offload.

Change-Id: I705cbdcad97f3b004e3b5cdf7fc671a25ed9262d
