### PR TITLE
bacon: Untangle playback modes, for real this time

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -22,8 +22,6 @@ ro.gps.agps_provider=1
 
 # Media
 af.fast_track_multiplier=1
-
-audio.deep_buffer.media=true
 audio_hal.period_size=192
 persist.audio.fluence.voicecall=true
 ro.qc.sdk.audio.fluencetype=fluence
@@ -33,7 +31,7 @@ audio.offload.buffer.size.kb=32
 audio.offload.video=true
 audio.offload.multiple.enabled=false
 audio.offload.gapless.enabled=true
-audio.offload.pcm.16bit.enable=false
+audio.offload.pcm.16bit.enable=true
 audio.offload.pcm.24bit.enable=true
 av.streaming.offload.enable=true
 


### PR DESCRIPTION
- Remove forced deep buffer, this causes endless glitches with
  streams that really should be on the low-latency path.
- 16-bit PCM offload is safe with this configuration now and
  navigation is no longer glitchy.

Change-Id: I7b37eed41c5f573b8ceca5b087e1d109c554a7fd
